### PR TITLE
[PyTorch] Add unfused CP all-to-all op

### DIFF
--- a/docs/api/pytorch.rst
+++ b/docs/api/pytorch.rst
@@ -198,6 +198,8 @@ Operation fuser
 
 .. autoapiclass:: transformer_engine.pytorch.ops.ConstantScale
 
+.. autoapiclass:: transformer_engine.pytorch.ops.ContextParallelAllToAll
+
 .. autoapiclass:: transformer_engine.pytorch.ops.Dropout
 
 .. autoapiclass:: transformer_engine.pytorch.ops.GEGLU

--- a/docs/examples/op_fuser/op_fuser.rst
+++ b/docs/examples/op_fuser/op_fuser.rst
@@ -567,3 +567,58 @@ forward/backward pair must be jointly equivalent.
 
     # Register joint fusion with operation fuser
     te.ops.register_forward_backward_fusion(fuse_linear_silu)
+Unfused context-parallel example
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``ContextParallelAllToAll`` is an example of the first step in adding a
+new fusion. It is a ``BasicOperation`` that defines the numerical and
+autograd contract using ordinary PyTorch collectives. There is intentionally
+no fused kernel or registered replacement yet, so the operation fuser runs
+the linear and all-to-all as separate operations.
+
+The basic operation uses flattened 2-D tensors. ``sequence_to_head`` maps
+``[local_tokens, full_features]`` to ``[global_tokens, local_features]`` and
+``head_to_sequence`` applies the inverse mapping. Attention-specific layout
+adapters, including dual-chunk or THD reordering, are outside this contract.
+All ranks must provide the same number of local token rows.
+
+.. code-block:: python
+
+    import transformer_engine.pytorch as te
+
+    # cp_group has P ranks. projection_features is divisible by P.
+    before_attention = te.ops.Sequential(
+        te.ops.BasicLinear(hidden_size, projection_features),
+        te.ops.ContextParallelAllToAll(
+            cp_group,
+            direction="sequence_to_head",
+        ),
+    )
+    after_attention = te.ops.Sequential(
+        te.ops.ContextParallelAllToAll(
+            cp_group,
+            direction="head_to_sequence",
+        ),
+        te.ops.BasicLinear(projection_features, hidden_size),
+    )
+
+    qkv_shard = before_attention(x)
+    attention_out = local_attention(qkv_shard)
+    out = after_attention(attention_out)
+
+On the first call, each ``Sequential`` groups its adjacent
+``FusibleOperation`` objects into an ``OperationFuser``. The fuser scans its
+registered replacement functions. Since no CP fusion is registered, it keeps
+the basic operations and executes their ``op_forward`` methods. Its custom
+autograd function later calls ``op_backward`` in reverse order; the all-to-all
+backward is the inverse layout exchange.
+
+A future optimized implementation would add two ``FusedOperation`` classes
+and registration functions that recognize these exact windows:
+
+* ``BasicLinear -> ContextParallelAllToAll(sequence_to_head)``
+* ``ContextParallelAllToAll(head_to_sequence) -> BasicLinear``
+
+The fused operation must produce the same outputs and gradients as the basic
+operations. The operation fuser only performs pattern replacement; it does not
+need to understand context-parallel semantics.

--- a/tests/pytorch/distributed/test_fusible_ops.py
+++ b/tests/pytorch/distributed/test_fusible_ops.py
@@ -319,6 +319,85 @@ def _test_reduce_scatter(
     torch.testing.assert_close(dx_test, dx_ref, rtol=0, atol=0)
 
 
+def _test_context_parallel_all_to_all(
+    *,
+    local_tokens: int = 5,
+    local_features: int = 7,
+    dtype: torch.dtype = torch.float32,
+    device: torch.device = "cuda",
+) -> None:
+    """Check both CP-A2A directions and their inverse gradients."""
+    process_group = world_group()
+    rank = torch.distributed.get_rank(process_group)
+    world_size = torch.distributed.get_world_size(process_group)
+    full_features = world_size * local_features
+
+    # Replicate the global reference on each rank so expected peer slices can
+    # be computed without using the implementation under test.
+    x_global = torch.arange(
+        world_size * local_tokens * full_features,
+        dtype=dtype,
+        device=device,
+    ).reshape(world_size, local_tokens, full_features)
+    grad_head_global = torch.arange(
+        world_size * world_size * local_tokens * local_features,
+        dtype=dtype,
+        device=device,
+    ).reshape(world_size, world_size * local_tokens, local_features)
+
+    x = x_global[rank].clone().requires_grad_()
+    expected_head = torch.cat(
+        [
+            x_global[src, :, rank * local_features : (rank + 1) * local_features]
+            for src in range(world_size)
+        ],
+        dim=0,
+    )
+    expected_dx = torch.cat(
+        [
+            grad_head_global[dst].reshape(world_size, local_tokens, local_features)[
+                rank
+            ]
+            for dst in range(world_size)
+        ],
+        dim=-1,
+    )
+
+    to_head = te_ops.ContextParallelAllToAll(
+        process_group=process_group,
+        direction="sequence_to_head",
+    )
+    head = to_head(x)
+    head.backward(grad_head_global[rank])
+    torch.testing.assert_close(head, expected_head, rtol=0, atol=0)
+    torch.testing.assert_close(x.grad, expected_dx, rtol=0, atol=0)
+
+    grad_sequence_global = torch.arange(
+        world_size * local_tokens * full_features,
+        dtype=dtype,
+        device=device,
+    ).reshape(world_size, local_tokens, full_features)
+    expected_dhead = torch.cat(
+        [
+            grad_sequence_global[src][
+                :, rank * local_features : (rank + 1) * local_features
+            ]
+            for src in range(world_size)
+        ],
+        dim=0,
+    )
+
+    head_input = expected_head.clone().requires_grad_()
+    to_sequence = te_ops.ContextParallelAllToAll(
+        process_group=process_group,
+        direction="head_to_sequence",
+    )
+    sequence = to_sequence(head_input)
+    sequence.backward(grad_sequence_global[rank])
+    torch.testing.assert_close(sequence, x_global[rank], rtol=0, atol=0)
+    torch.testing.assert_close(head_input.grad, expected_dhead, rtol=0, atol=0)
+
+
 def _test_basic_linear(
     *,
     local_weight_shape: tuple[int, int] = (32, 32),
@@ -978,6 +1057,9 @@ def run_parallel_tests() -> None:
     if rank == 0:
         print(f"Running _test_reduce_scatter")
     _test_reduce_scatter()
+    if rank == 0:
+        print("Running _test_context_parallel_all_to_all")
+    _test_context_parallel_all_to_all()
 
     # Basic linear op
     for config in itertools.product(

--- a/transformer_engine/pytorch/ops/basic/__init__.py
+++ b/transformer_engine/pytorch/ops/basic/__init__.py
@@ -24,6 +24,7 @@ from .all_reduce import AllReduce
 from .basic_linear import BasicLinear
 from .bias import Bias
 from .constant_scale import ConstantScale
+from .context_parallel_all_to_all import ContextParallelAllToAll
 from .dropout import Dropout
 from .grouped_linear import GroupedLinear, is_op_fuser_grouped_tensor_path_supported
 from .identity import Identity

--- a/transformer_engine/pytorch/ops/basic/context_parallel_all_to_all.py
+++ b/transformer_engine/pytorch/ops/basic/context_parallel_all_to_all.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+
+"""Fusible operation for context-parallel all-to-all."""
+
+from __future__ import annotations
+from typing import Literal, Optional
+
+import torch
+
+from .._common import maybe_dequantize
+from ..op import BasicOperation, OperationContext
+from ...tensor import Quantizer
+
+
+class ContextParallelAllToAll(BasicOperation):
+    """Exchange sequence and feature shards for Ulysses context parallelism.
+
+    This is the unfused semantic reference for the communication adjacent to
+    projection GEMMs. Inputs use a deliberately small 2-D contract so that a
+    future fused operation can replace either ``BasicLinear ->
+    ContextParallelAllToAll`` or ``ContextParallelAllToAll -> BasicLinear``
+    without inheriting attention-layout policy.
+
+    ``"sequence_to_head"`` maps ``[local_tokens, full_features]`` to
+    ``[global_tokens, local_features]``. ``"head_to_sequence"`` applies the
+    inverse mapping. Rows received from peers are ordered by source rank.
+    ``local_tokens`` must be equal on every rank because this reference uses
+    equal-size all-to-all splits.
+
+    This operation does not implement BSHD/SBHD adapters, dual-chunk sequence
+    reordering, THD padding, or ``cu_seqlens`` handling. Those transformations
+    belong outside this basic operation unless a future kernel's documented
+    output contract includes them.
+
+    Parameters
+    ----------
+    process_group : torch.distributed.ProcessGroup, default = world group
+        Context-parallel process group.
+    direction : {"sequence_to_head", "head_to_sequence"}
+        Direction of the context-parallel layout exchange.
+
+    """
+
+    def __init__(
+        self,
+        process_group: Optional[torch.distributed.ProcessGroup] = None,
+        *,
+        direction: Literal["sequence_to_head", "head_to_sequence"] = "sequence_to_head",
+    ) -> None:
+        super().__init__()
+        if direction not in ("sequence_to_head", "head_to_sequence"):
+            raise ValueError(
+                "ContextParallelAllToAll direction must be "
+                f"'sequence_to_head' or 'head_to_sequence' (got {direction!r})"
+            )
+        self.process_group: Optional[torch.distributed.ProcessGroup] = process_group
+        self.direction = direction
+
+    def _sequence_to_head(self, input_: torch.Tensor) -> torch.Tensor:
+        """Gather token rows while sharding the last dimension."""
+        group_size = torch.distributed.get_world_size(self.process_group)
+        if input_.dim() != 2:
+            raise ValueError(
+                "ContextParallelAllToAll expects a 2-D tensor, "
+                f"but got shape={list(input_.shape)}"
+            )
+        local_tokens, full_features = input_.shape
+        if full_features % group_size != 0:
+            raise ValueError(
+                "The feature dimension must be divisible by the context-parallel "
+                f"group size ({full_features=}, {group_size=})"
+            )
+        if group_size == 1:
+            return input_.detach()
+
+        local_features = full_features // group_size
+        send = input_.reshape(local_tokens, group_size, local_features)
+        send = send.movedim(1, 0).contiguous()
+        recv = torch.empty_like(send)
+        torch.distributed.all_to_all_single(recv, send, group=self.process_group)
+        return recv.reshape(group_size * local_tokens, local_features)
+
+    def _head_to_sequence(self, input_: torch.Tensor) -> torch.Tensor:
+        """Shard token rows while gathering the last dimension."""
+        group_size = torch.distributed.get_world_size(self.process_group)
+        if input_.dim() != 2:
+            raise ValueError(
+                "ContextParallelAllToAll expects a 2-D tensor, "
+                f"but got shape={list(input_.shape)}"
+            )
+        global_tokens, local_features = input_.shape
+        if global_tokens % group_size != 0:
+            raise ValueError(
+                "The token dimension must be divisible by the context-parallel "
+                f"group size ({global_tokens=}, {group_size=})"
+            )
+        if group_size == 1:
+            return input_.detach()
+
+        local_tokens = global_tokens // group_size
+        send = input_.reshape(group_size, local_tokens, local_features).contiguous()
+        recv = torch.empty_like(send)
+        torch.distributed.all_to_all_single(recv, send, group=self.process_group)
+        return recv.movedim(0, 1).reshape(local_tokens, group_size * local_features)
+
+    def op_forward(
+        self,
+        ctx: OperationContext,
+        input_: torch.Tensor,
+        prev_op_grad_output_quantizer: Optional[Quantizer],
+        next_op_input_quantizer: Optional[Quantizer],
+    ) -> torch.Tensor:
+        del ctx, prev_op_grad_output_quantizer, next_op_input_quantizer
+        input_ = maybe_dequantize(input_)
+        if self.direction == "sequence_to_head":
+            return self._sequence_to_head(input_)
+        return self._head_to_sequence(input_)
+
+    def op_backward(
+        self,
+        ctx: OperationContext,
+        grad_output: torch.Tensor,
+    ) -> tuple[torch.Tensor, tuple[()]]:
+        del ctx
+        grad_output = maybe_dequantize(grad_output)
+        if self.direction == "sequence_to_head":
+            grad_input = self._head_to_sequence(grad_output)
+        else:
+            grad_input = self._sequence_to_head(grad_output)
+        return grad_input, ()


### PR DESCRIPTION
## Summary

- add `te.ops.ContextParallelAllToAll` as an unfused `BasicOperation`
- support inverse `sequence_to_head` and `head_to_sequence` exchanges in forward and backward
- export the operation and document how it composes with `BasicLinear`
- add distributed numerical coverage for both layouts and gradients

## Why

This establishes the always-correct semantic and autograd reference needed before registering future GEMM/all-to-all fused replacements. The initial contract is deliberately narrow: flattened 2-D tensors with source-rank-major rows and equal token counts across ranks.

Attention-specific BSHD/SBHD adapters, dual-chunk ordering, THD padding, and `cu_seqlens` handling remain outside the basic op because the proposed fused-kernel ABI does not yet establish those semantics.

## Scope

This PR does not add a fused kernel, fusion matcher, or MHA integration. Current MHA projections still use the legacy module `Linear`; an ops-based projection path or adapter is a later integration step.

## Validation

- Python syntax compilation
- Black formatting check
- Pylint on `transformer_engine/pytorch/ops/basic/context_parallel_all_to_all.py`
- `git diff --check`
- focused two-rank Gloo forward/backward checks for both directions

The full GPU distributed suite was not run because the local checkout TE extension is ABI-incompatible with the available PyTorch development container.